### PR TITLE
Update Logic to Disable Sentry

### DIFF
--- a/.github/workflows/docker-release-image.yml
+++ b/.github/workflows/docker-release-image.yml
@@ -26,22 +26,6 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract metadata for Docker without Sentry
-        id: meta-no-sentry
-        uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          flavor: latest=false
-          tags: type=semver,pattern={{version}}
-
-      - name: Build and push Docker Image without Sentry
-        uses: docker/build-push-action@37abcedcc1da61a57767b7588cb9d03eb57e28b3
-        with:
-          context: .
-          push: true
-          tags: ${{ steps.meta-no-sentry.outputs.tags }}-no-sentry
-          labels: ${{ steps.meta-no-sentry.outputs.labels }}
-
       - name: Extract metadata for Docker with Sentry
         id: meta
         uses: docker/metadata-action@507c2f2dc502c992ad446e3d7a5dfbe311567a96

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -5,7 +5,7 @@ import type { HandleClientError } from "@sveltejs/kit";
 
 import { PUBLIC_SENTRY_DSN, PUBLIC_SENTRY_ENV } from "$env/static/public";
 
-const sentryIntegration = process.env.SENTRY
+const sentryIntegration = process.env.SENTRY;
 
 if (!sentryIntegration) {
   Sentry.init({

--- a/src/hooks.client.ts
+++ b/src/hooks.client.ts
@@ -5,7 +5,9 @@ import type { HandleClientError } from "@sveltejs/kit";
 
 import { PUBLIC_SENTRY_DSN, PUBLIC_SENTRY_ENV } from "$env/static/public";
 
-if (PUBLIC_SENTRY_DSN) {
+const sentryIntegration = process.env.SENTRY
+
+if (!sentryIntegration) {
   Sentry.init({
     dsn: PUBLIC_SENTRY_DSN,
     environment: PUBLIC_SENTRY_ENV,
@@ -15,7 +17,7 @@ if (PUBLIC_SENTRY_DSN) {
 }
 
 export const handleError = (({ error, event }) => {
-  if (PUBLIC_SENTRY_DSN) {
+  if (!sentryIntegration) {
     const errorId = crypto.randomUUID();
 
     Sentry.setTag("Leagueify", "Frontend");

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -8,7 +8,7 @@ import type { Handle, HandleServerError } from "@sveltejs/kit";
 import { PUBLIC_SENTRY_DSN, PUBLIC_SENTRY_ENV } from "$env/static/public";
 import { leagueData } from "$lib/stores";
 
-const sentryIntegration = process.env.SENTRY
+const sentryIntegration = process.env.SENTRY;
 
 if (!sentryIntegration) {
   Sentry.init({

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -8,7 +8,9 @@ import type { Handle, HandleServerError } from "@sveltejs/kit";
 import { PUBLIC_SENTRY_DSN, PUBLIC_SENTRY_ENV } from "$env/static/public";
 import { leagueData } from "$lib/stores";
 
-if (PUBLIC_SENTRY_DSN) {
+const sentryIntegration = process.env.SENTRY
+
+if (!sentryIntegration) {
   Sentry.init({
     dsn: PUBLIC_SENTRY_DSN,
     environment: PUBLIC_SENTRY_ENV,
@@ -34,7 +36,7 @@ export const handle = (async ({ event, resolve }) => {
 }) satisfies Handle;
 
 export const handleError = (({ error, event }) => {
-  if (PUBLIC_SENTRY_DSN) {
+  if (!sentryIntegration) {
     Sentry.setTag("Leagueify", "Backend");
     Sentry.captureException(error, { event });
 


### PR DESCRIPTION
This updates how sentry is disabled. Instead of building two images, if a user adds `SENTRY: false` to the docker-compose environment variables, Sentry will be disabled.