### PR TITLE
Update CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-* @MichaelCduBois
-* @kylekrny
+* @MichaelCduBois @kylekrny


### PR DESCRIPTION
Previously, the CODEOWNERS file was setup incorrectly as the second line was overwriting the first line. As shown in the [CODEOWNERS Documentation](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#example-of-a-codeowners-file), all owners that have the same ownership level, should be on the same line.