### PR TITLE
Add initial installation workflow redirect step

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,10 +9,11 @@ datasource db {
 }
 
 model League {
-  id      Int     @id @default(autoincrement())
-  name    String  @db.VarChar(255)
-  sport   Sport   @relation(fields: [sportId], references: [id])
-  sportId Int
+  id            Int     @id @default(autoincrement())
+  name          String  @db.VarChar(255)
+  outboundEmail String  @unique @db.VarChar(64)
+  sport         Sport   @relation(fields: [sportId], references: [id])
+  sportId       Int
 }
 
 model Sport {

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,21 @@
+import { redirect } from "@sveltejs/kit";
+import type { Handle } from "@sveltejs/kit";
+
+import database from "$lib/server/database";
+
+export const handle = (async ({ event, resolve }) => {
+  if (event.url.pathname === "/register") {
+    const response = await resolve(event);
+    return response;
+  }
+
+  const user = await database.user.findMany();
+
+  if (user.length === 0) {
+    throw redirect(307, "/register");
+  }
+
+  // Handle all other requests
+  const response = await resolve(event);
+  return response;
+}) satisfies Handle;

--- a/src/lib/server/database.ts
+++ b/src/lib/server/database.ts
@@ -1,0 +1,5 @@
+import { PrismaClient } from "@prisma/client";
+
+const database = new PrismaClient();
+
+export default database;

--- a/src/routes/register/+page.svelte
+++ b/src/routes/register/+page.svelte
@@ -1,0 +1,4 @@
+<h1>Register SvelteKit</h1>
+<p>
+  Visit <a href="https://kit.svelte.dev">kit.svelte.dev</a> to read the documentation
+</p>


### PR DESCRIPTION
If a user is not preset within the league database, the user is redirected to `/register` to continue throughout the process.