### PR TITLE
262 unable to run development stack

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -13,7 +13,11 @@ services:
       PUBLIC_SENTRY: false
     command: npm run dev -- --host --port=3000
     volumes:
-      - ./:/usr/src/app/
+      - ./prisma/:/home/node/app/prisma/
+      - ./scripts/:/home/node/app/scripts/
+      - ./src/:/home/node/app/src/
+      - ./static/:/home/node/app/static/
+      - ./tests/:/home/node/app/tests/
 
   leagueify-database:
     container_name: leagueify-database-dev

--- a/dockerfile
+++ b/dockerfile
@@ -1,9 +1,13 @@
 FROM node:18.12.1-alpine3.17 as development
+USER node
 
-WORKDIR /usr/src/app
-COPY . ./
+RUN mkdir -p /home/node/app
+WORKDIR /home/node/app
+COPY --chown=node:node package.json package-lock.json ./
 
 RUN npm install
+
+COPY --chown=node:node . .
 
 # Generate Licenses
 # RUN node scripts/getLicenses.mjs
@@ -19,9 +23,9 @@ RUN npm ci
 FROM builder as production
 
 WORKDIR /app
-COPY --from=builder /usr/src/app/build .
-COPY --from=builder /usr/src/app/package.json .
-COPY --from=builder /usr/src/app/node_modules ./node_modules
-COPY --from=builder /usr/src/app/prisma ./prisma
+COPY --chown=node:node --from=builder /home/node/app/build .
+COPY --chown=node:node --from=builder /home/node/app/package.json .
+COPY --chown=node:node --from=builder /home/node/app/node_modules ./node_modules
+COPY --chown=node:node --from=builder /home/node/app/prisma ./prisma
 
 CMD [ "npm", "start" ]


### PR DESCRIPTION
Resolves permission errors with vite. @kylekrny let me know if you are able to build and run the image within docker.